### PR TITLE
[USS-1292] Wait until replica update finishes

### DIFF
--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/elastic/cloud-sdk-go/pkg/util/slice"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
@@ -207,7 +208,30 @@ func (c *clientImpl) UpdateIndexReplicaNum(ctx context.Context, indexName string
 		return fmt.Errorf("update number_of_replica: %w", err)
 	}
 
-	// TODO: wait until shard relocation finishes
+	return c.waitUntilIndexBecomeHealthy(ctx, indexName)
+}
 
-	return nil
+func (c *clientImpl) waitUntilIndexBecomeHealthy(ctx context.Context, indexName string) error {
+	ticker := time.NewTicker(1 * time.Minute)
+	consecutiveErrCount := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			indexHealth, err := c.GetIndexHealth(ctx, indexName)
+			if err != nil {
+				consecutiveErrCount += 1
+				if consecutiveErrCount == 3 {
+					return fmt.Errorf("get index health: %w", err)
+				}
+				continue
+			}
+			consecutiveErrCount = 0
+
+			if indexHealth.IsHealthy() {
+				return nil
+			}
+		}
+	}
 }

--- a/pkg/elasticsearch/client_test.go
+++ b/pkg/elasticsearch/client_test.go
@@ -549,7 +549,25 @@ func Test_clientImpl_UpdateIndexReplicaNum(t *testing.T) {
 				indexName:  "test",
 				replicaNum: 2,
 			},
-			esClient: newESClientWithMockResponse(200, `{"acknowledged": true}`),
+			esClient: newESClientWithMockResponse(200, `
+{
+  "cluster_name": "dummy_cluster_name",
+  "status": "green",
+  "timed_out": false,
+  "number_of_nodes": 1,
+  "number_of_data_nodes": 1,
+  "active_primary_shards": 1,
+  "active_shards": 1,
+  "relocating_shards": 0,
+  "initializing_shards": 0,
+  "unassigned_shards": 0,
+  "delayed_unassigned_shards": 0,
+  "number_of_pending_tasks": 0,
+  "number_of_in_flight_fetch": 0,
+  "task_max_waiting_in_queue_millis": 0,
+  "active_shards_percent_as_number": 100
+}
+`),
 		},
 		{
 			name: "error response",


### PR DESCRIPTION
## Summary
Fix to wait until replica update finishes to prevent running scaling down before finishing replica update.

## Ticket
- https://mercari.atlassian.net/browse/USS-1292